### PR TITLE
[FIX] Add avatar to the projects page

### DIFF
--- a/ui/src/projects.vue
+++ b/ui/src/projects.vue
@@ -158,7 +158,7 @@ export default {
             this.loading = true;
             this.$http.get('project/query', {params: {
                 q: this.query,
-                select: 'name desc group_id stats.datasets stats.instances create_date admins members guests access',
+                select: 'name desc avatar group_id stats.datasets stats.instances create_date admins members guests access',
             }}).then(res=>{
                 this.projects = res.data;
 


### PR DESCRIPTION
Include the avatar into the projects page. Now, the projects query does not ask for the avatar field. By doing so, it is returned in the response, and Vue renders it:

![image](https://user-images.githubusercontent.com/562525/170052923-efdb1dac-b128-4137-8ad5-00f6ed6494c3.png)

![image](https://user-images.githubusercontent.com/562525/170052857-d49b12a9-3406-44ca-a678-dbc44a4f6925.png)
