### PR TITLE
CDM-1: Adding file to create presigned URL from s3 bucket object.

### DIFF
--- a/api/presignedURL.js
+++ b/api/presignedURL.js
@@ -1,0 +1,53 @@
+const AWS = require('aws-sdk');
+const fs = require('fs');
+const path = require('path');
+
+// Read the AWS secret access key from the aws.key file
+const secretAccessKey = fs.readFileSync(path.join(__dirname, 'config', 'aws.key'), 'utf8').trim();
+
+// Configure AWS with credentials and region
+const s3 = new AWS.S3({
+    accessKeyId: 'FQAQ3RWRSCR6POF2NCQC',
+    secretAccessKey: secretAccessKey,
+    endpoint: 'https://s3.msi.umn.edu',
+    s3ForcePathStyle: true,
+    region: 'us-east-1'
+});
+
+// Function to list objects in a bucket
+const listObjects = async (bucketName) => {
+    const params = {
+        Bucket: bucketName
+    };
+
+    try {
+        const data = await s3.listObjectsV2(params).promise();
+        console.log('Objects in bucket:', data.Contents);
+
+        // Filter the objects to only show zarr files
+        // const zarrFiles = data.Contents.filter(obj => obj.Key.endsWith('.zarr'));
+        // console.log('Zarr files in bucket:', zarrFiles);
+    } catch (err) {
+        console.error('Error listing objects:', err);
+    }
+};
+
+// Function to generate a presigned URL for an S3 object
+const generatePresignedURL = (bucketName, key, expiresIn) => {
+    const params = {
+        Bucket: bucketName,
+        Key: key,
+        Expires: expiresIn
+    };
+
+    return s3.getSignedUrl('getObject', params);
+};
+
+const bucketName = 'midb-cmc-nonhuman';
+const key = 'PS-OCT/KQRH/3D Tiles/A1A2/slice_155_tile_33_CH1.mat';
+const expiresIn = 60 * 10; // URL expires in 10 minutes
+
+const url = generatePresignedURL(bucketName, key, expiresIn);
+console.log('Presigned URL:', url);
+
+// listObjects(bucketName);


### PR DESCRIPTION
User will need to create an aws.key file in the api.config directory of warehouse and add the secret key. Right now I have it set up with a hard-coded object in the MSI bucket, but we can change the object key to whatever we want. There's also functionality in this file to list all objects in the MSI bucket and filter by file type. The presigned URL (once created) is set to expire after 10 mins, but this can be changed. 