### PR TITLE
Update `Report Issues` link

### DIFF
--- a/ui/src/components/sidemenu.vue
+++ b/ui/src/components/sidemenu.vue
@@ -207,7 +207,7 @@ export default {
         },
 
         reportbug() {
-            window.open("https://github.com/brainlife/brainlife/issues", "github");
+            window.open("https://github.com/orgs/brainlife/discussions", "github");
         },
 
         login() {


### PR DESCRIPTION
Hi Brainlife team, the current link goes to 404.  Not sure which repository would be desirable so I just updated the link to the organization-level `Discussions` tab.  Happy to update based on your suggestions.

Fix https://github.com/brainlife/docs/issues/132